### PR TITLE
Update python_tips_1.ipynb

### DIFF
--- a/python_tips_1.ipynb
+++ b/python_tips_1.ipynb
@@ -85,8 +85,8 @@
    "source": [
     "pies = ['apple', 'blueberry', 'lemon']\n",
     "\n",
-    "for num, i in enumerate(pies):\n",
-    "    print(num, ':', i)"
+    "for i, pie in enumerate(pies):\n",
+    "    print(i, ':', pie)"
    ]
   },
   {


### PR DESCRIPTION
More typical to use `i` as an iteration variable and a common-sense name ("pie") for the iterator content.