### PR TITLE
Python Version Update to 3.8.X and Section Additions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ If the page notebooks won't load on GitHub view them here:
  - `Python Tips <https://nbviewer.jupyter.org/github/gpetepg/python_tips/blob/master/python_tips.ipynb/>`_.
  - `Built-In-Libraries <https://nbviewer.jupyter.org/github/gpetepg/python_tips/blob/master/built_in_library_tips.ipynb/>`_.
 
-Note that these were written in Python 3 (3.6)
+Note that these were written in Python 3 (3.8.X).
 
 These files are .ipynb. It is a notebook document used by Jupyter Notebook, an interactive computational environment designed to help scientists work with the Python language (as well as many others e.g. R, Julia, Ruby, JavaScript).
 

--- a/built_in_functions_and_libraries.ipynb
+++ b/built_in_functions_and_libraries.ipynb
@@ -238,7 +238,7 @@
     {
      "data": {
       "text/plain": [
-       "<zip at 0x104c902c8>"
+       "<zip at 0x7fa3184bf680>"
       ]
      },
      "execution_count": 9,
@@ -459,7 +459,8 @@
      "text": [
       "These are very useful you can use f-strings on this too.\n",
       "These will keep the formatting within the string\n",
-      "\n"
+      "\n",
+      "name='tyler'\n"
      ]
     }
    ],
@@ -470,7 +471,12 @@
     "\n",
     "print(f\"\"\"These are very useful you can use {string} on this too.\n",
     "These will keep the formatting within the string\n",
-    "\"\"\")"
+    "\"\"\")\n",
+    "\n",
+    "#You can also print the value and variable name together like this:\n",
+    "\n",
+    "name = \"tyler\"\n",
+    "print(f\"{name=}\")"
    ]
   },
   {
@@ -811,7 +817,7 @@
     {
      "data": {
       "text/plain": [
-       "'2020-02-04 10:43:54.614899'"
+       "'2022-08-23 15:19:10.314056'"
       ]
      },
      "execution_count": 33,
@@ -835,7 +841,7 @@
     {
      "data": {
       "text/plain": [
-       "'datetime.datetime(2020, 2, 4, 10, 43, 54, 629390)'"
+       "'datetime.datetime(2022, 8, 23, 15, 19, 10, 329810)'"
       ]
      },
      "execution_count": 34,
@@ -876,7 +882,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itertools import *"
+    "from itertools import * #does not work"
    ]
   },
   {
@@ -915,6 +921,9 @@
     "\n",
     "This creates an iterable object that goes up by the step you specify.\n",
     "This will continuously yield increments of 5 i.e. 0, 5, 10, 15, 20...\n",
+    "\n",
+    "Remember: Each time your generator is called upon using next, it will only then yield the result. \n",
+    "This will continue until your generator is exhausted.\n",
     "\n",
     "Do not use as a list.\n",
     "\"\"\"\n",
@@ -993,6 +1002,7 @@
     "\"\"\"repeat(object, times=None)\n",
     "\n",
     "Used to repeat an element up to n times.\n",
+    "\n",
     "\n",
     "Works as a generator.\n",
     "\"\"\"\n",
@@ -1099,7 +1109,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+      "['a', 'b', 'c', 'e', 'd', 'f', 'g', 'h', 'i', 'j', 'k', 'l']\n"
      ]
     }
    ],
@@ -1148,7 +1158,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+      "['a', 'b', 'c', 'e', 'd', 'f', 'g', 'h', 'i', 'j', 'k', 'l']\n"
      ]
     }
    ],
@@ -1233,6 +1243,9 @@
    ],
    "source": [
     "# Generator\n",
+    "\n",
+    "#Remember: Each time your generator is called upon using next, it will only then yield the result. \n",
+    "#This will continue until your generator is exhausted.\n",
     "\n",
     "compress_obj = compress(\"ABCDEF\", [1, 0, 1, 0, 1, 1])\n",
     "\n",
@@ -1662,7 +1675,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(<itertools._tee object at 0x104ce6bc8>, <itertools._tee object at 0x104ce4bc8>, <itertools._tee object at 0x104ce4c48>)\n"
+      "(<itertools._tee object at 0x7fa3183be840>, <itertools._tee object at 0x7fa3183bed40>, <itertools._tee object at 0x7fa3183be540>)\n"
      ]
     }
    ],
@@ -1672,9 +1685,10 @@
     "Tee will take the iterable that you give it \n",
     "and return a tuple of n iterables, which you can then iterate through. \n",
     "\"\"\"\n",
+    "b = tee((1,2,3,4), 3)\n",
+    "print(b) #outputs ([1,2,3,4], [1,2,3,4], [1,2,3,4])\n",
     "\n",
-    "b = tee((1, 2, 3, 4), 3)  # Created 3 iterable object with the same elements\n",
-    "print(b)"
+    "# b = itertools.tee((1,2,3,4), 3) outputs the same thing as above"
    ]
   },
   {
@@ -1686,74 +1700,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n"
+      "[1, 2, 3, 4]\n",
+      "[1, 2, 3, 4]\n",
+      "[1, 2, 3, 4]\n",
+      "[]\n",
+      "[]\n",
+      "[]\n"
      ]
     }
    ],
    "source": [
-    "for first in b[0]:\n",
-    "    print(first)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n"
-     ]
-    }
-   ],
-   "source": [
-    "for second in b[1]:\n",
-    "    print(second)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 65,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n"
-     ]
-    }
-   ],
-   "source": [
-    "for third in b[2]:\n",
-    "    print(third)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Will raise IndexError uncomment to run.\n",
-    "\n",
-    "# for third in b[3]:\n",
-    "#     print(third)"
+    "# Created 3 iterable object with the same elements\n",
+    "for i in range(0,3):\n",
+    "    print(list(b[i]))\n",
+    "for i in range(0,3): #Remember they are iterators so they're designed to generate data exactly one time. \n",
+    "    print(list(b[i]))#If you want to get data out of it a second time, you either have to save \n",
+    "                     #all the iterated data to another list, or initiate the iterator again."
    ]
   },
   {
@@ -1765,7 +1727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -1797,7 +1759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -1810,6 +1772,9 @@
    ],
    "source": [
     "zip_longest_obj = zip_longest(\"ABCD\", \"xy\", fillvalue=\"-\")\n",
+    "\n",
+    "#Remember: Each time your generator is called upon using next, it will only then yield the result. \n",
+    "#This will continue until your generator is exhausted.\n",
     "\n",
     "print(next(zip_longest_obj))"
    ]
@@ -1832,7 +1797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
@@ -1841,7 +1806,7 @@
        "[('A',), ('B',), ('C',), ('D',)]"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1861,7 +1826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
@@ -1885,7 +1850,7 @@
        " ('D', 'D')]"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1896,7 +1861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -1922,7 +1887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 69,
    "metadata": {
     "scrolled": true
    },
@@ -1944,7 +1909,7 @@
        " ('D', 'C')]"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1962,7 +1927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -1988,7 +1953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -1997,7 +1962,7 @@
        "[('A', 'B'), ('A', 'C'), ('A', 'D'), ('B', 'C'), ('B', 'D'), ('C', 'D')]"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2016,7 +1981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -2042,7 +2007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 73,
    "metadata": {
     "scrolled": true
    },
@@ -2062,7 +2027,7 @@
        " ('D', 'D')]"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2072,6 +2037,7 @@
     "\n",
     "Returns all combinations with replacements,\n",
     "Results in sorted order\n",
+    "r represents the size/length of different combinations that are possible\n",
     "\n",
     "The list should return with these additional elements:\n",
     "[(\"A\", \"A\"), (\"B\", \"B\"), (\"C\", \"C\"), (\"D\", \"D\")]\n",
@@ -2084,7 +2050,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
@@ -2119,7 +2085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2135,7 +2101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -2147,11 +2113,32 @@
     }
    ],
    "source": [
-    "\"\"\"namedtuple(typename, field_names, verbose=False, rename=False)\n",
+    "\"\"\"namedtuple(typename, field_names, rename=False) # verbose=False argument was removed in Python 3.7\n",
     "\n",
-    "Used to create tuple-like objects that act like lists\n",
-    "dictionaries. Very good at being descriptive check.\n",
+    "A factory function used to create tuple-like IMMUTABLE objects that act like lists\n",
+    "dictionaries. Use named tuples instead of tuples anywhere \n",
+    "you think object notation will make your code more easily readable.\n",
+    "Note that the the VALUES they store don’t have to be immutable\n",
+    "but attributes in named tuples are immutable.\n",
     "\n",
+    "\n",
+    "required arguments:\n",
+    "\n",
+    "typename    - the class name represented as a string\n",
+    "field_names - the field names you'll use to access the tuple values\n",
+    "                - can be an iterable of strings\n",
+    "                - can be a string with values separated by white space\n",
+    "                - can be a string with values separated by commas\n",
+    "\n",
+    "optional arguments:\n",
+    "\n",
+    "rename   - if set to true, all invalid field names are replaced with positional names\n",
+    "defaults - defaulted to None, which means field names won't have default values. Can \n",
+    "           be set to an iterable of values\n",
+    "module   - the .__module__ attribute of the resulting namedtuple is set to this given value\n",
+    "           \n",
+    "\n",
+    "named tuple methods:\n",
     "._make          creates list like tuple\n",
     "\n",
     "._asdict()      creates dict like tuple\n",
@@ -2172,7 +2159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2181,7 +2168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -2190,7 +2177,7 @@
        "255"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2203,7 +2190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 79,
    "metadata": {
     "scrolled": true
    },
@@ -2214,7 +2201,7 @@
        "255"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2231,7 +2218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -2260,7 +2247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -2269,7 +2256,7 @@
        "descriptor(x=33, y=22)"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2283,7 +2270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
@@ -2292,7 +2279,7 @@
        "('x', 'y')"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2312,7 +2299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
@@ -2379,7 +2366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -2400,7 +2387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -2421,7 +2408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
@@ -2442,7 +2429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -2458,7 +2445,7 @@
        "1"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2474,7 +2461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -2495,7 +2482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
@@ -2516,7 +2503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -2538,7 +2525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -2560,7 +2547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
@@ -2584,7 +2571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [
     {
@@ -2608,7 +2595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [
     {
@@ -2644,67 +2631,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 95,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'a': 1, 'b': 2, 'c': 3}, {'c': 4, 'd': 5, 'e': 6}]\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"ChainMap(*maps)\n",
     "\n",
     "A ChainMap class is provided for quickly linking\n",
     "a number of mappings so they can be treated as a single unit.\n",
     "\n",
-    "If there a key that is the same within the ChainMap object, \n",
-    "it will assign the value to the first instance of that key.\n",
+    "Identical keys within the ChainMap object will all have\n",
+    "the value of the first instance of that key.\n",
     "\"\"\"\n",
     "\n",
     "dict1 = {\"a\":1, \"b\":2, \"c\":3}\n",
     "dict2 = {\"c\":4, \"d\":5, \"e\":6}\n",
     "\n",
-    "chained = ChainMap(dict1,dict2)"
+    "chained = ChainMap(dict1,dict2)\n",
+    "print(chained.maps) #maps operation displays keys and values"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "2"
-      ]
-     },
-     "execution_count": 99,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['c', 'd', 'e', 'a', 'b']\n"
+     ]
     }
    ],
    "source": [
-    "chained[\"b\"]"
+    "print(list(chained.keys())) #keys operation displays keys"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": 97,
+   "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 100,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3, 5, 6, 1, 2]\n"
+     ]
     }
    ],
    "source": [
-    "# Assigned 3 not 4 because dict1 was paased first.\n",
-    "\n",
-    "chained[\"c\"]"
+    "print (list(chained.values())) #values operation displays values"
    ]
   },
   {
@@ -2716,7 +2702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -2725,7 +2711,7 @@
        "Counter({1: 3, 2: 3, 3: 3, 5: 3, 7: 3, 4: 3, 9: 3})"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2755,7 +2741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2763,6 +2749,8 @@
     "\n",
     "An OrderedDict is a dict that remembers\n",
     "the order that keys were first inserted.\n",
+    "If a new entry overwrites an existing entry,\n",
+    "the order is left unchanged.\n",
     "\"\"\"\n",
     "\n",
     "ordered_dict = OrderedDict({\"a\":1, \"b\":2, \"c\":3, \"d\":4})"
@@ -2770,7 +2758,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [
     {
@@ -2779,7 +2767,7 @@
        "OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 4)])"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2790,7 +2778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [
     {
@@ -2820,7 +2808,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [
     {
@@ -2852,7 +2840,7 @@
     "    else:\n",
     "        d[letter] += 1\n",
     "        \n",
-    "print(d)\n",
+    "print(d) \n",
     "        \n",
     "# Similar to\n",
     "\n",
@@ -2865,7 +2853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
@@ -2874,7 +2862,7 @@
        "[('yellow', [1, 3]), ('blue', [2, 4]), ('red', [1])]"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2899,34 +2887,20 @@
     "### Functools<a id='functools'></a>\n",
     "[Return to table of contents](#toc)\n",
     "\n",
-    "The functools module is for higher-order functions: functions that act on or return other functions. In general, any callable object can be treated as a function for the purposes of this module.\n",
+    "The functools module is for higher-order functions: functions that act on or return other functions. In general, any callable object can be treated as a function for the purposes of this module. Functools has a lot of wrapper tools and functionality. Partial and reduce are very good to know. I may add more to this section later.\n",
     "\n",
     "https://docs.python.org/3/library/functools.html#functools.partial"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Functools has a lot of wrapper tools and functionality. \\nI may go over them at some point. For now I think partial and reduce\\nare very good to know.\\n'"
-      ]
-     },
-     "execution_count": 107,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": 104,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
    "source": [
-    "from functools import *\n",
-    "\n",
-    "\"\"\"Functools has a lot of wrapper tools and functionality. \n",
-    "I may go over them at some point. For now I think partial and reduce\n",
-    "are very good to know.\n",
-    "\"\"\""
+    "from functools import *"
    ]
   },
   {
@@ -2938,7 +2912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2959,7 +2933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
@@ -2983,7 +2957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [
     {
@@ -3031,7 +3005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [
     {
@@ -3040,7 +3014,7 @@
        "3628800"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3050,10 +3024,11 @@
     "\n",
     "Reduce needs to be imported in Python3.x\n",
     "\n",
-    "Reduce is a really useful function for performing some computation on a list and returning the result.\n",
+    "Reduce is a useful function for performing some computation on a list and returning the result.\n",
     "It applies a rolling computation to sequential pairs of values in a list. This one is tricky.\n",
     "\n",
-    "Easiest example to understnad is trying to multiply a whole list together i.e 1*2*3*4*5*6*7*8*9*10\n",
+    "Easiest example to understand is trying to multiply a whole list together like shown below \n",
+    "i.e 1*2*3*4*5*6*7*8*9*10\n",
     "\"\"\"\n",
     "\n",
     "list_1 = list(range(1,11))\n",
@@ -3063,7 +3038,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -3072,7 +3047,7 @@
        "10"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3085,7 +3060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 110,
    "metadata": {
     "scrolled": true
    },
@@ -3096,7 +3071,7 @@
        "1"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3114,7 +3089,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
@@ -3123,7 +3098,7 @@
        "'lru_cache(maxsize=128, typed=False)\\n\\nDecorator to wrap a function with a memoizing callable that saves up to the maxsize most recent calls.\\n'"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3137,7 +3112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3152,7 +3127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3176,7 +3151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3206,7 +3181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3215,16 +3190,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2020, 2, 4, 10, 43, 55, 762863)"
+       "datetime.datetime(2022, 8, 23, 15, 19, 11, 519484)"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3242,7 +3217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 117,
    "metadata": {
     "scrolled": true
    },
@@ -3251,7 +3226,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Today is the 4 day of month 2, and the year is 2020!\n"
+      "Today is the 23 day of month 8, and the year is 2022!\n"
      ]
     }
    ],
@@ -3276,14 +3251,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The current month is February.\n"
+      "The current month is August.\n"
      ]
     }
    ],
@@ -3304,14 +3279,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Today's date is 04-02-2020. Be careful; It's not a datetimeobject anymore it is a <class 'str'>!\n"
+      "Today's date is 23-08-2022. Be careful; It's not a datetimeobject anymore it is a <class 'str'>!\n"
      ]
     }
    ],
@@ -3332,7 +3307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 120,
    "metadata": {
     "scrolled": true
    },
@@ -3381,7 +3356,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3390,7 +3365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3401,7 +3376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3412,14 +3387,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "['LICENSE.md',\n",
-       " '.DS_Store',\n",
        " 'random_tips.ipynb',\n",
        " 'functions_and_classes.ipynb',\n",
        " 'built_in_functions_and_libraries.ipynb',\n",
@@ -3430,7 +3404,7 @@
        " '.git']"
       ]
      },
-     "execution_count": 127,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3441,7 +3415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3454,7 +3428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3467,7 +3441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3478,7 +3452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3500,7 +3474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3511,7 +3485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [
     {
@@ -3520,7 +3494,7 @@
        "'python_tips'"
       ]
      },
-     "execution_count": 133,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3533,7 +3507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3544,7 +3518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3555,7 +3529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [
     {
@@ -3564,7 +3538,7 @@
        "True"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3577,7 +3551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [
     {
@@ -3586,7 +3560,7 @@
        "True"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3599,7 +3573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 135,
    "metadata": {},
    "outputs": [
     {
@@ -3608,7 +3582,7 @@
        "False"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 135,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3621,7 +3595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 136,
    "metadata": {},
    "outputs": [
     {
@@ -3630,7 +3604,7 @@
        "('file', '.txt')"
       ]
      },
-     "execution_count": 139,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3658,7 +3632,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/functions_and_classes.ipynb
+++ b/functions_and_classes.ipynb
@@ -708,7 +708,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<function html_wrap.<locals>.msg_to_wrap at 0x7ff4125f15e0>\n"
+      "<function html_wrap.<locals>.msg_to_wrap at 0x7f971fde1b80>\n"
      ]
     }
    ],
@@ -881,7 +881,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[*] Execution time: 0.46527695655822754 seconds.\n"
+      "[*] Execution time: 0.39233899116516113 seconds.\n"
      ]
     }
    ],
@@ -1072,11 +1072,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<function num at 0x7ff4125bff70> func1\n",
+      "<function num at 0x7f9720103280> func1\n",
       "1\n",
-      "<function decorator.<locals>.inner1 at 0x7ff4125bf430> func2\n",
+      "<function decorator.<locals>.inner1 at 0x7f97201035e0> func2\n",
       "2\n",
-      "<function decorator1.<locals>.inner2 at 0x7ff4125bf160> func3\n",
+      "<function decorator1.<locals>.inner2 at 0x7f97201039d0> func3\n",
       "3\n",
       "4\n",
       "5\n",
@@ -1588,7 +1588,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<__main__.Dog object at 0x7ff4125e8820>\n"
+      "<__main__.Dog object at 0x7f972011f130>\n"
      ]
     }
    ],
@@ -1606,7 +1606,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__.Dog at 0x7ff4125e8820>"
+       "<__main__.Dog at 0x7f972011f130>"
       ]
      },
      "execution_count": 66,
@@ -1654,7 +1654,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__.Dog at 0x7ff4128ac7f0>"
+       "<__main__.Dog at 0x7f9720117850>"
       ]
      },
      "execution_count": 68,
@@ -1793,7 +1793,7 @@
    "source": [
     "<u>Static Methods</u>\n",
     "\n",
-    "The staticmethod decorator allows us to include methods within a class that do not pertain to the class object we are working with. It is essentially a normal function attached to our class.\n",
+    "The static method decorator allows us to include methods within a class that do not pertain to the class object we are working with. It is essentially a normal function attached to our class.\n",
     "\n",
     "We generally use static methods to create utility functions."
    ]

--- a/functions_and_classes.ipynb
+++ b/functions_and_classes.ipynb
@@ -708,7 +708,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<function html_wrap.<locals>.msg_to_wrap at 0x10c2fa0d0>\n"
+      "<function html_wrap.<locals>.msg_to_wrap at 0x7ff4125f15e0>\n"
      ]
     }
    ],
@@ -767,12 +767,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@wrapper\n",
+    "\n",
     "def message(tag, msg, tab=True):\n",
     "    if tab:\n",
     "        print(\"\\t\", msg)\n",
     "    else:\n",
-    "        print(msg)"
+    "        print(msg)\n",
+    "message = wrapper(message)"
    ]
   },
   {
@@ -795,6 +796,57 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def hello_decorator(func):\n",
+    "    def inner():\n",
+    "        print(\"guten tag\")\n",
+    "        func()        \n",
+    "        print(\"sayonara\")\n",
+    "    return inner()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "guten tag\n",
+      "nice weather we got\n",
+      "sayonara\n",
+      "guten tag\n",
+      "nice weather we got\n",
+      "sayonara\n"
+     ]
+    }
+   ],
+   "source": [
+    "def func_used():\n",
+    "    print(\"nice weather we got\")\n",
+    "    \n",
+    "func_used = hello_decorator(func_used)\n",
+    "\n",
+    "#The above code is equivalent to the code below\n",
+    "\n",
+    "@hello_decorator\n",
+    "def func_used():\n",
+    "    print(\"nice weather we got\")\n",
+    "    \n",
+    "#hello_decorator is a callable function, that will add some code on top of some other \n",
+    "#callable function(func_used function) and return the wrapper function \n",
+    "\n",
+    "#In decorators, functions are taken as the argument into another function \n",
+    "#and then called inside the wrapper function."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -803,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -822,14 +874,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[*] Execution time: 0.4786849021911621 seconds.\n"
+      "[*] Execution time: 0.46527695655822754 seconds.\n"
      ]
     }
    ],
@@ -844,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -894,7 +946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -917,7 +969,7 @@
        "10"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -931,7 +983,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -940,7 +992,7 @@
        "100"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -955,7 +1007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -964,7 +1016,7 @@
        "50"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -978,7 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -987,7 +1039,7 @@
        "2500"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1004,22 +1056,97 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Recursion<a id=\"recursion\"></a>\n",
-    "[Return to table of contents](#toc)\n",
+    "<b>Chaining Decorators</b>\n",
     "\n",
-    "A recursive function is a function which either calls itself or is in a potential cycle of function calls. \n",
-    "\n",
-    "Using a recursion function to find factoials. Here is a simple diagram I put together."
+    "Order of execution for decorators: \n",
+    "From decorator above the function where the decorator is taken as an argument, then upwards.\n",
+    "See example below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<function num at 0x7ff4125bff70> func1\n",
+      "1\n",
+      "<function decorator.<locals>.inner1 at 0x7ff4125bf430> func2\n",
+      "2\n",
+      "<function decorator1.<locals>.inner2 at 0x7ff4125bf160> func3\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "300\n"
+     ]
+    }
+   ],
+   "source": [
+    "def decorator2(func):\n",
+    "    print(func, 'func3')\n",
+    "    def inner3():\n",
+    "        print(4)\n",
+    "        x = func() #x = decorator1(decorator(num()))\n",
+    "        print(9)\n",
+    "        return x * 10 #num is now returning 300\n",
+    "    print(3)\n",
+    "    return inner3()\n",
+    "\n",
+    "def decorator1(func):\n",
+    "    print(func, 'func2')\n",
+    "    def inner2():\n",
+    "      print(5)\n",
+    "      x = func() #x = decorator(num())\n",
+    "      print(8)\n",
+    "      return x * 2 #num is now returning 30\n",
+    "    print(2)\n",
+    "    return inner2\n",
+    "\n",
+    "def decorator(func): #starts at num returning 10\n",
+    "    print(func, 'func1')\n",
+    "    def inner1():\n",
+    "      print(6)\n",
+    "      x = func() #x = num(), which returns 10\n",
+    "      print(7)\n",
+    "      return x + 5 #num is now returning 15\n",
+    "    print(1)\n",
+    "    return inner1\n",
+    "  \n",
+    "@decorator2 #goes third\n",
+    "@decorator1 #goes second\n",
+    "@decorator #goes first\n",
+    "def num():\n",
+    "    return 10\n",
+    "print(num)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Recursion<a id=\"recursion\"></a>\n",
+    "[Return to table of contents](#toc)\n",
+    "\n",
+    "A recursive function is a function which either calls itself or is in a potential cycle of function calls that uses a base case to exit out of the cycle.\n",
+    "\n",
+    "Using a recursion function to find factorials. Here is a simple diagram I put together."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
     "def factorial(n):\n",
-    "    if n < 2:\n",
+    "    if n < 2: #base case\n",
     "        return 1\n",
     "    else:\n",
     "        return n * factorial(n-1)"
@@ -1027,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -1036,7 +1163,7 @@
        "120"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1055,14 +1182,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Another example finding the fibonacci sequence of the nth term.\n",
     "\n",
     "def fib(n):\n",
-    "    if n == 1 or n == 2:\n",
+    "    if n == 1 or n == 2: #base case\n",
     "        return 1\n",
     "    else:\n",
     "        return fib(n-2) + fib(n-1)"
@@ -1070,7 +1197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -1079,7 +1206,7 @@
        "55"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1109,7 +1236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1144,7 +1271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -1153,7 +1280,7 @@
        "'Todd'"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1165,7 +1292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -1174,7 +1301,7 @@
        "'Manager'"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1186,7 +1313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -1195,7 +1322,7 @@
        "10"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1217,7 +1344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -1226,7 +1353,7 @@
        "9"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1256,7 +1383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1287,7 +1414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -1296,7 +1423,7 @@
        "'a'"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1329,7 +1456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1343,7 +1470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1352,7 +1479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 61,
    "metadata": {
     "scrolled": true
    },
@@ -1371,7 +1498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
@@ -1397,7 +1524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -1442,7 +1569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1454,14 +1581,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<__main__.Dog object at 0x10cb68438>\n"
+      "<__main__.Dog object at 0x7ff4125e8820>\n"
      ]
     }
    ],
@@ -1473,16 +1600,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<__main__.Dog at 0x10cb68438>"
+       "<__main__.Dog at 0x7ff4125e8820>"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1493,7 +1620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1514,7 +1641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -1527,10 +1654,10 @@
     {
      "data": {
       "text/plain": [
-       "<__main__.Dog at 0x10cb68860>"
+       "<__main__.Dog at 0x7ff4128ac7f0>"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1545,7 +1672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1563,7 +1690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -1579,7 +1706,7 @@
        "Dog(Snoopy, Beagle)"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1598,7 +1725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1621,7 +1748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -1637,7 +1764,7 @@
        "Dog(Snoopy, Beagle)"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1684,7 +1811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
@@ -1692,7 +1819,7 @@
      "output_type": "stream",
      "text": [
       "21\n",
-      "24\n",
+      "26\n",
       "True\n"
      ]
     }
@@ -1751,7 +1878,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1771,7 +1898,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
@@ -1780,7 +1907,7 @@
        "5"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1792,7 +1919,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -1801,7 +1928,7 @@
        "3"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1833,7 +1960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1855,7 +1982,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -1864,7 +1991,7 @@
        "'Guy Fieri'"
       ]
      },
-     "execution_count": 75,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1895,7 +2022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1912,7 +2039,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -1936,7 +2063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -1957,7 +2084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1977,7 +2104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
@@ -2008,7 +2135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2037,7 +2164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -2072,7 +2199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2100,7 +2227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -2123,7 +2250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2147,7 +2274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
@@ -2188,7 +2315,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/general_tips.ipynb
+++ b/general_tips.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# TABLE OF CONTENTS:<a id='toc'></a>\n",
     "\n",
-    "These tips are focused on general Python tips I think that are good to know.\n",
+    "These tips are focused on general Python tips I think are good to know.\n",
     "\n",
     "Please go through official documentation if you want more thorough examples.\n",
     "\n",
@@ -700,7 +700,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/random_tips.ipynb
+++ b/random_tips.ipynb
@@ -195,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated all files to work in Python 3.8.X and expanded on the following sections:

Functions and Classes notebook
- decorators with decorator chaining and syntax comparisons

Built-in Libraries and Functions notebook
  - itertools tee 
  - combinations with replacements
  - named tuple
  - chain maps
  - OrderedDict
  - f-string